### PR TITLE
Improve markup, tweak narrow-screen sizing

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -20,7 +20,7 @@ details {
 
 summary {
   cursor: pointer;
-  font-size: 4rem;
+  font-size: 2rem;
   text-align: center;
 }
 
@@ -35,13 +35,18 @@ h1 {
   line-height: 1.25;
 }
 
-.Slider-Wrapper > * {
+.Slider-Wrapper form * {
   display: block;
-  font-size: 1.5rem;
+  font-size: 1rem;
   font-weight: 600;
 }
 
-.Slider-Wrapper > * + * {
+.Slider-Wrapper input {
+  max-width: 100%;
+  margin: 0;
+}
+
+.Slider-Wrapper form > * + * {
   margin-top: 0.5rem;
 }
 
@@ -57,9 +62,11 @@ h1 {
 }
 
 footer {
-  background-color: white;
   position: sticky;
   bottom: 0;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  background-color: white;
 }
 
 .ByFuturice {
@@ -77,4 +84,15 @@ footer {
 
 img {
   max-width: 100%;
+}
+
+/* Media queries for wider screens */
+@media screen and (min-width: 42em) {
+  summary {
+    font-size: 4rem;
+  }
+
+  .Slider-Wrapper form * {
+    font-size: 1.5rem;
+  }
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -35,43 +35,50 @@ function App() {
       });
   }, 1000);
   return (
-    <main className="App" style={{ "--image-size": `${imageSize}rem` }}>
-      <details>
-        <summary>
-          <h1>Selfie Party 🎉</h1>
-        </summary>
-        <div className="Slider-Wrapper">
-          <form>
-            <label for="image-size">Image size</label>
-            <input
-              id="imageSize"
-              name="imageSize"
-              type="range"
-              min="4"
-              max="48"
-              value={imageSize}
-              onChange={ev => {
-                setImageSize(ev.target.value);
-              }}
-            ></input>
-            <output name="imageSizeOutput" id="imageSizeOutput">
-              {imageSize}
-            </output>
-          </form>
+    <>
+      <main className="App" style={{ "--image-size": `${imageSize}rem` }}>
+        <details>
+          <summary>
+            <h1>
+              Selfie Party{" "}
+              <span role="img" aria-label="Tada!">
+                🎉
+              </span>
+            </h1>
+          </summary>
+          <div className="Slider-Wrapper">
+            <form>
+              <label for="image-size">Image size</label>
+              <input
+                id="imageSize"
+                name="imageSize"
+                type="range"
+                min="4"
+                max="48"
+                value={imageSize}
+                onChange={ev => {
+                  setImageSize(ev.target.value);
+                }}
+              ></input>
+              <output name="imageSizeOutput" id="imageSizeOutput">
+                {imageSize}
+              </output>
+            </form>
+          </div>
+        </details>
+        <div className="Gallery">
+          {photos.map((photo, index) => {
+            return (
+              <img
+                // TODO: Make this the filename once the images are unique
+                key={index}
+                alt={photo.description ? photo.description : ""}
+                src={`http://localhost:5000/photo/${photo.filename}`}
+              />
+            );
+          })}
         </div>
-      </details>
-      <div className="Gallery">
-        {photos.map((photo, index) => {
-          return (
-            <img
-              // TODO: Make this the filename once the images are unique
-              key={index}
-              alt={photo.description ? photo.description : ""}
-              src={`http://localhost:5000/photo/${photo.filename}`}
-            />
-          );
-        })}
-      </div>
+      </main>
       <footer>
         <span className="ByFuturice">
           <span>by</span>
@@ -90,7 +97,7 @@ function App() {
           </svg>
         </span>
       </footer>
-    </main>
+    </>
   );
 }
 


### PR DESCRIPTION
This PR is mostly a cleanup on some of the work we did over the weekend.

In particular:
- I noticed that the `footer` was a child of `main`, when it should be a sibling
- Tweaked the `input` slider to work bettter with different browsers. For example, `display: block` and max-width
- Enhance the font-size from medium to large betwen narrow screens and wide screens
- Make the emoji more accessible

That's all!