### PR TITLE
Change the way git ignores photos/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 telegram.config
 backend/env
-backend/photos
 frontend/node_modules
 pics.db

--- a/backend/photos/.gitignore
+++ b/backend/photos/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
We don't want the contents of backend/photos to end up in git.
But as the script currently requires that folder to exist and silently
fails if it doesn't, this one makes sure the folder is part of the repository.

In future changes, the script should either check if the folder exists and if not,
either create it or fail with proper error.